### PR TITLE
MkDocs Auto-Patch

### DIFF
--- a/auto-patch.py
+++ b/auto-patch.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import re
+from subprocess import check_output
+try:
+    import mkdocs
+except ImportError:
+    raise ImportError('mkdocs does not appear to be installed. Install mkdocs before mkdocs-nbconvert')
+
+def get_init_file():
+    """ Get the location of the init directory
+    """
+    mkdoc_path = os.path.dirname(mkdocs.__file__)
+    init_file = os.path.join(mkdoc_path, 'utils', '__init__.py')
+
+    return init_file
+
+if __name__ == '__main__':
+    init_file = get_init_file()
+
+    with open(init_file, 'r') as f:
+        init_code = f.read()
+
+    regexp = 'markdown_extensions = ([^\]]*)\]'
+    search_groups = re.search(regexp, init_code)
+    extension_def = search_groups.group(0)
+
+    current_extensions = [s.strip().split(',')[0] for s in extension_def.split('\n')[1:-1]]
+        
+    # Make sure extension isn't present already
+    new_ext = "'%s'" % '.ipynb'
+    if new_ext not in current_extensions:
+        current_extensions.append(new_ext)
+
+    formatted_extensions = ['    ' + e for e in current_extensions]
+    formatted_extensions = ',\n'.join(formatted_extensions)
+   
+
+    # regenerate string
+    new_block= 'markdown_extensions = [\n' + formatted_extensions + '\n]'
+
+    new_code = re.sub(regexp, new_block, init_code)
+
+    with open(init_file, 'w') as f:
+        f.write(new_code)

--- a/mkdocs_nbconvert/nbconvert.py
+++ b/mkdocs_nbconvert/nbconvert.py
@@ -18,15 +18,16 @@ class NotebookConverter(BasePlugin):
     def on_page_read_source(self, something, **kwargs):
         page = kwargs['page']
         config = kwargs['config']
+        input_path = page.file.src_path
 
-        if not self.can_load(page.input_path):
+        if not self.can_load(input_path):
             return
 
-        ipynb_path = os.path.join(config['docs_dir'], page.input_path)
+        ipynb_path = os.path.join(config['docs_dir'], input_path)
         nb = nbformat.read(ipynb_path, as_version=4)
 
         # we'll place the supporting files alongside the final HTML
-        stem = os.path.splitext(os.path.basename(page.input_path))[0]
+        stem = os.path.splitext(os.path.basename(input_path))[0]
         exporter_resources = {'output_files_dir': stem} 
         
         (body, resources) = self.exporter.from_notebook_node(nb,

--- a/mkdocs_nbconvert/nbconvert.py
+++ b/mkdocs_nbconvert/nbconvert.py
@@ -19,14 +19,14 @@ class NotebookConverter(BasePlugin):
         page = kwargs['page']
         config = kwargs['config']
 
-        if not self.can_load(path.input_path):
+        if not self.can_load(page.input_path):
             return
 
-        ipynb_path = os.path.join(config['docs_dir'], path.input_path)
+        ipynb_path = os.path.join(config['docs_dir'], page.input_path)
         nb = nbformat.read(ipynb_path, as_version=4)
 
         # we'll place the supporting files alongside the final HTML
-        stem = os.path.splitext(os.path.basename(path.input_path))[0]
+        stem = os.path.splitext(os.path.basename(page.input_path))[0]
         exporter_resources = {'output_files_dir': stem} 
         
         (body, resources) = self.exporter.from_notebook_node(nb,

--- a/mkdocs_nbconvert/nbconvert.py
+++ b/mkdocs_nbconvert/nbconvert.py
@@ -18,16 +18,15 @@ class NotebookConverter(BasePlugin):
     def on_page_read_source(self, something, **kwargs):
         page = kwargs['page']
         config = kwargs['config']
-        input_path = page.file.src_path
 
-        if not self.can_load(input_path):
+        if not self.can_load(path.input_path):
             return
 
-        ipynb_path = os.path.join(config['docs_dir'], input_path)
+        ipynb_path = os.path.join(config['docs_dir'], path.input_path)
         nb = nbformat.read(ipynb_path, as_version=4)
 
         # we'll place the supporting files alongside the final HTML
-        stem = os.path.splitext(os.path.basename(input_path))[0]
+        stem = os.path.splitext(os.path.basename(path.input_path))[0]
         exporter_resources = {'output_files_dir': stem} 
         
         (body, resources) = self.exporter.from_notebook_node(nb,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 
 from distutils.core import setup
 
+# Automatically edit the mkdocs/utils/__init__.py to include 
+# .ipynb extensions.
+from subprocess import call
+call(['python', 'auto-patch.py'])
+
 setup(
     name='mkdocs-nbconvert',
     version='0.1.0',
@@ -19,4 +24,3 @@ setup(
         ]
     }
 )
-


### PR DESCRIPTION
This pull request adds a new auto-patching feature to make a no-hassle setup for the user. This patch extracts the current list of valid markdown extensions from `mkdocs/utils/__init__.py` and appends `'.ipynb'` if it does not already exist in the list. The location is detected automatically via the following approach,

```python
import os
import mkdocs
mkdoc_package_dir = os.path.dirname(mkdocs.__file__)
```

which should be robust against virtual environment installations. Additionally, the `auto-patch.py` includes a check to make sure that mkdocs is installed first, and will throw an `ImportError` if it is not, requesting that the user first install Mkdocs. 